### PR TITLE
Adding windows compilation support

### DIFF
--- a/include/ela/ela.h
+++ b/include/ela/ela.h
@@ -20,12 +20,17 @@
  */
 
 #include <stdint.h>
-#include <sys/time.h>
+
+#if !defined(_MSC_VER)
+# include <sys/time.h>
+#endif
 
 /* GCC visibility */
 #if defined(__GNUC__) && __GNUC__ >= 4 /** mkdoc:skip */
 /** @internal */
 # define ELA_EXPORT __attribute__ ((visibility("default")))
+#elif defined(_MSC_VER) /** mkdoc:skip */
+# define ELA_EXPORT __declspec(dllexport)
 #else
 /** @internal */
 # define ELA_EXPORT

--- a/include/ela/libevent.h
+++ b/include/ela/libevent.h
@@ -27,6 +27,7 @@ struct event_base;
 
    @returns an event loop, or NULL if libevent support is unavailable.
  */
+ELA_EXPORT
 struct ela_el *ela_libevent(struct event_base *event);
 
 #endif

--- a/src/ela.c
+++ b/src/ela.c
@@ -15,10 +15,10 @@
 #include <stdio.h>
 #include <string.h>
 
-#if 0
-# define DBG(a...) printf(a)
+#if 1
+# define DBG(a, ...) printf(a, __VA_ARGS__)
 #else
-# define DBG(a...) do{}while(0)
+# define DBG(a, ...) do{}while(0)
 #endif
 
 ela_error_t ela_set_fd(


### PR DESCRIPTION
Fixing macros so they work in MS Visual Studio 2013 and changing abstracting compiler-specific attributes.
